### PR TITLE
chore: copy pre-commit hook in Makefile, rewrite README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ CONFIG_FILE := ./etc/debug-config.yaml
 
 .PHONY: help
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: setup
+setup: pre-commit golangci-lint goimports swaggo ## Setup development environment with all tools and hooks.
+	@echo "Development environment setup completed!"
 
 ##@ Development
 
@@ -65,9 +69,14 @@ docs: swaggo ## Generate docs docs.
 	$(SWAGGO) init -g cmd/crater/main.go -q --parseInternal --parseDependency
 
 .PHONY: run
-run: fmt docs imports ## Run a controller from your host.
+run: fmt docs imports pre-commit ## Run a controller from your host.
 	export KUBECONFIG="$(KUBECONFIG_PATH)" && \
 	go run cmd/crater/main.go --config-file "$(CONFIG_FILE)"
+
+.PHONY: pre-commit-check
+pre-commit-check: pre-commit ## Run pre-commit hook manually.
+	@echo "Running pre-commit hook..."
+	@$(GIT_HOOKS_DIR)/pre-commit && echo "Pre-commit hook completed successfully! You can now commit with confidence." || echo "Pre-commit hook failed! Please fix the issues and try again."
 
 ##@ Build
 
@@ -79,9 +88,9 @@ build: fmt lint docs ## Build manager binary.
 build-migrate: fmt lint ## Build migration binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/migrate cmd/gorm-gen/models/migrate.go
 
-##@ Build Dependencies
+##@ Development Tools
 
-## Location to install dependencies to
+## Location to install tools to
 LOCATION ?= $(PWD)/bin
 $(LOCATION):
 	mkdir -p $(LOCATION)
@@ -114,3 +123,19 @@ swaggo: $(SWAGGO) ## Install swaggo
 $(SWAGGO): $(LOCATION)
 	@echo "Installing swag $(SWAGGO_VERSION)..."
 	GOBIN=$(LOCATION) go install github.com/swaggo/swag/cmd/swag@$(SWAGGO_VERSION)
+
+##@ Git Hooks
+
+## Location to install git hooks to
+GIT_HOOKS_DIR ?= $(PWD)/.git/hooks
+$(GIT_HOOKS_DIR):
+	@echo "Creating git hooks directory..."
+	@mkdir -p $(GIT_HOOKS_DIR)
+
+.PHONY: pre-commit
+pre-commit: $(GIT_HOOKS_DIR)/pre-commit ## Install git pre-commit hook.
+$(GIT_HOOKS_DIR)/pre-commit: $(GIT_HOOKS_DIR) .githook/pre-commit
+	@echo "Installing git pre-commit hook..."
+	@cp .githook/pre-commit $(GIT_HOOKS_DIR)/pre-commit
+	@chmod +x $(GIT_HOOKS_DIR)/pre-commit
+	@echo "Git pre-commit hook installed successfully!"

--- a/cmd/gorm-gen/README.md
+++ b/cmd/gorm-gen/README.md
@@ -1,8 +1,11 @@
 # Crater Gorm Gen
 
+Before generating code, first use `kubectl` to port-forward the database in the cluster to your local machine. Alternatively, if port forwarding is already configured in the cluster, you can directly connect to the database in the cluster.
+
+
 在生成代码前，首先通过 Kubectl 将集群中的数据库转发到本地。或者在集群配置了端口转发的情况下，可以直接连接集群中的数据库。
 
 ```bash
-go run cmd/gorm-gen/models/migrate.go
-go run cmd/gorm-gen/curd/generate.go
+make migrate
+make curd
 ```


### PR DESCRIPTION
### Makefile

- Added `pre-commit` and `pre-commit-check` targets for copying and manually executing scripts, integrated them into existing workflows to achieve automatic installation and updates.

- Added `setup` target for manually installing tools and Git scripts.

### README

- Almost completely rewrote the README to adapt to the existing development workflow and provided more comprehensive documentation for required configuration files.